### PR TITLE
Update dependency on widdershins to 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "widdershins": "Mermade/widdershins#two_oh"
+    "widdershins": "2.1.4"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
The Mermade/widdershins#two_oh branch isn't on github anymore, so the
old version doesn't work.

I'm not sure whether there might have been breaking changes since that
branch, but it seems to work well enough for Verify's nefarious
purposes.

Authors: @richardtowers